### PR TITLE
Improve Travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: java
-install: true
+
 jdk:
 - oraclejdk8
+- oraclejdk11
 
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
   - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,9 @@ cache:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
 
-script:
-- ./gradlew build publish
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: ./gradlew publish
+    on:
+      jdk: oraclejdk8


### PR DESCRIPTION
This fixes some issues with the Travis CI setup and makes the tests be ran on both JDK8 and JDK11 (currently the Oracle flavor is used).

The full effect of these changes is:
 - default `install` phase is used (runs `./gradlew assemble` to get dependencies)
 - default `script` phase is used (runs `./gradlew check` to build and run tests and checks)
 - `deploy` phase is customized to only run on the JDK8 build (runs `./gradlew publish` to upload artifacts)

Using the `deploy` phase also fixes issue where PR builds would upload artifacts.