### PR TITLE
Fixed InfluxDB Reporter about reached max connection pool size problem

### DIFF
--- a/reporter-influxdb/src/main/java/io/ultrabrew/metrics/reporters/influxdb/InfluxDBClient.java
+++ b/reporter-influxdb/src/main/java/io/ultrabrew/metrics/reporters/influxdb/InfluxDBClient.java
@@ -117,7 +117,12 @@ public class InfluxDBClient {
     HttpPost httpPost = new HttpPost(this.dbUri);
     httpPost.setEntity(new ByteArrayEntity(byteBuffer.array(), ContentType.DEFAULT_TEXT));
     CloseableHttpResponse response = httpClient.execute(httpPost);
-    int statusCode = response.getStatusLine().getStatusCode();
+    int statusCode;
+    try {
+      statusCode = response.getStatusLine().getStatusCode();
+    } finally {
+      EntityUtils.consumeQuietly(response.getEntity());
+    }
     // Always clear the buffer. But this will lead to data loss in case of non 2xx response (i.e write operation failed)
     // received from the InfluxDB server. Ideally non 2xx server response should be rare but revisit this part
     // if data loss occurs frequently.
@@ -126,6 +131,5 @@ public class InfluxDBClient {
       throw new IOException("InfluxDB write failed: " + statusCode + " " + response.getStatusLine()
           .getReasonPhrase());
     }
-    EntityUtils.consumeQuietly(response.getEntity());
   }
 }


### PR DESCRIPTION
### Problem
* Reached max connection pool size and report processing stops, when received StatusCode != 2xx response six times.
  * Following exception is output and report processing has stopped.  
    ```
    [2019-03-18 10:34:43,101] ERROR Failed to send data (io.ultrabrew.metrics.reporters.influxdb.InfluxDBReporter)
    org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:313)
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:279)
    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:191)
    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185)
    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
    at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
    at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
    at io.ultrabrew.metrics.reporters.influxdb.InfluxDBClient.flush(InfluxDBClient.java:119)
    at io.ultrabrew.metrics.reporters.influxdb.InfluxDBClient.write(InfluxDBClient.java:102)
    at io.ultrabrew.metrics.reporters.c.InfluxDBReporter.doReport(InfluxDBReporter.java:51)
    at io.ultrabrew.metrics.reporters.TimeWindowReporter.report(TimeWindowReporter.java:65)
    at io.ultrabrew.metrics.reporters.TimeWindowReporter.run(TimeWindowReporter.java:111)
    at java.lang.Thread.run(Thread.java:748)
    ```
  * Following code is the cause.
  https://github.com/ultrabrew/metrics/blob/e1e38520ca5332def16801e37eec111aa8efede2/reporter-influxdb/src/main/java/io/ultrabrew/metrics/reporters/influxdb/InfluxDBClient.java#L51-L52
  https://github.com/ultrabrew/metrics/blob/e1e38520ca5332def16801e37eec111aa8efede2/reporter-influxdb/src/main/java/io/ultrabrew/metrics/reporters/influxdb/InfluxDBClient.java#L119-L129
* Similar problems are expected to occur in the case of receive invalid response.