### PR TITLE
Enforce dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ subprojects {
     dependencyCheck {
         skipConfigurations = ['clover', 'jmh']
         format = 'ALL'
+        failBuildOnCVSS = 4.0
     }
 
     spotbugs {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ subprojects {
     check.dependsOn cloverGenerateReport, dependencyCheckAnalyze
 
     dependencyCheck {
-        skipConfigurations = ['clover']
+        skipConfigurations = ['clover', 'jmh']
         format = 'ALL'
     }
 


### PR DESCRIPTION
Fail builds if a dependency has CVE with CVSS greater or equal to 4.0.