### PR TITLE
First cut: Free up stale rows feature for clients

### DIFF
--- a/core/src/main/java/io/ultrabrew/metrics/data/BasicCounterAggregator.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/BasicCounterAggregator.java
@@ -67,7 +67,7 @@ public class BasicCounterAggregator extends ConcurrentMonoidLongTable {
       final int cardinality) {
     super(metricId, maxCardinality, cardinality, FIELDS, TYPES, IDENTITY);
   }
-
+  
   @Override
   public void combine(final long[] table, final long baseOffset, final long value) {
     add(table, baseOffset, 0, value);

--- a/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
@@ -209,6 +209,12 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
       }
       return tagSets[i];
     }
+    
+    @Override
+    public void freeCurrentRow() {
+      // TODO Auto-generated method stub
+      
+    }
 
     @Override
     public long lastUpdated() {
@@ -259,5 +265,6 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
     public Type[] getTypes() {
       return types;
     }
+
   }
 }

--- a/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
@@ -209,13 +209,12 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
       }
       return tagSets[i];
     }
-    
+ ///CLOVER:OFF
     @Override
-    public void freeCurrentRow() {
-      // TODO Auto-generated method stub
-      
+    public String[] freeCurrentRow() {
+      return null;
     }
-
+ ///CLOVER:ON
     @Override
     public long lastUpdated() {
       if (i < 0 || i >= tagSets.length || tagSets[i] == null) {

--- a/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
@@ -171,7 +171,7 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
       }
       this.tagSets = tagSets;
       if (sorted) {
-        TagSetsHelper comparator = new TagSetsHelper(tagSets); 
+        TagSetsComparator comparator = new TagSetsComparator(tagSets); 
         Arrays.sort(sortedRef, comparator);
       }
     }

--- a/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/BasicHistogramAggregator.java
@@ -161,18 +161,18 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
     private int i = -1;
     private long base = 0;
     private int[] table;
-    private final Integer[] ref;
+    private final Integer[] sortedRef;
 
     private CursorImpl(final String[][] tagSets, final boolean sorted) {
       // Holds the indexes of tagSets in the case of sorted iteration
-      ref = new Integer[tagSets.length];
+      sortedRef = new Integer[tagSets.length];
       for (int i = 0; i < tagSets.length; i++) {
-        ref[i] = i;
+        sortedRef[i] = i;
       }
       this.tagSets = tagSets;
       if (sorted) {
         TagSetsHelper comparator = new TagSetsHelper(tagSets); 
-        Arrays.sort(ref, comparator);
+        Arrays.sort(sortedRef, comparator);
       }
     }
 
@@ -184,15 +184,15 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
     @Override
     public boolean next() {
       i++;
-      if (i >= tagSets.length || tagSets[ref[i]] == null) {
+      if (i >= tagSets.length || tagSets[sortedRef[i]] == null) {
         return false;
       }
 
-      long index = index(tagSets[ref[i]], true);
+      long index = index(tagSets[sortedRef[i]], true);
 
       if (NOT_FOUND == index) {
         LOGGER.error("Missing index on Read. Tags: {}. Concurrency error or bug",
-            Arrays.asList(tagSets[ref[i]]));
+            Arrays.asList(tagSets[sortedRef[i]]));
         return false;
       }
 
@@ -209,12 +209,13 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
 
     @Override
     public String[] getTags() {
-      if (i < 0 || i >= tagSets.length || tagSets[ref[i]] == null) {
-        throw new IndexOutOfBoundsException("Not a valid row index: " + ref[i]);
+      if (i < 0 || i >= tagSets.length || tagSets[sortedRef[i]] == null) {
+        throw new IndexOutOfBoundsException("Not a valid row index: " + sortedRef[i]);
       }
-      return tagSets[ref[i]];
+      return tagSets[sortedRef[i]];
     }
  ///CLOVER:OFF
+    // Will turn on Clover once this method is implemented.
     @Override
     public String[] freeCurrentRow() {
       return null;
@@ -222,16 +223,16 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
  ///CLOVER:ON
     @Override
     public long lastUpdated() {
-      if (i < 0 || i >= tagSets.length || tagSets[ref[i]] == null) {
-        throw new IndexOutOfBoundsException("Not a valid row index: " + ref[i]);
+      if (i < 0 || i >= tagSets.length || tagSets[sortedRef[i]] == null) {
+        throw new IndexOutOfBoundsException("Not a valid row index: " + sortedRef[i]);
       }
       return readTime(table, base);
     }
 
     @Override
     public long readLong(final int index) {
-      if (i < 0 || i >= tagSets.length || tagSets[ref[i]] == null) {
-        throw new IndexOutOfBoundsException("Not a valid row index: " + ref[i]);
+      if (i < 0 || i >= tagSets.length || tagSets[sortedRef[i]] == null) {
+        throw new IndexOutOfBoundsException("Not a valid row index: " + sortedRef[i]);
       }
       if (index < 0 || index >= fields.length) {
         throw new IndexOutOfBoundsException("Not a valid field index: " + index);
@@ -246,8 +247,8 @@ public class BasicHistogramAggregator extends ConcurrentMonoidIntTable implement
 
     @Override
     public long readAndResetLong(final int index) {
-      if (i < 0 || i >= tagSets.length || tagSets[ref[i]] == null) {
-        throw new IndexOutOfBoundsException("Not a valid row index: " + ref[i]);
+      if (i < 0 || i >= tagSets.length || tagSets[sortedRef[i]] == null) {
+        throw new IndexOutOfBoundsException("Not a valid row index: " + sortedRef[i]);
       }
       if (index < 0 || index >= fields.length) {
         throw new IndexOutOfBoundsException("Not a valid field index: " + index);

--- a/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidIntTable.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidIntTable.java
@@ -367,31 +367,10 @@ public abstract class ConcurrentMonoidIntTable {
                 // grow tag set
                 synchronized (this) {
                   if (tagIndex >= tagSets.length) {
-                    boolean isEqual = false;
-                    if(tagIndex == tagSets.length) {
-                      isEqual = true;
-                    }
                     final int oldLength = tagSets.length;
                     final int newLength =
                         oldLength > TAGSETS_MAX_INCREMENT ? oldLength + TAGSETS_MAX_INCREMENT
                             : oldLength * 2;
-                    String[][] newTagSet = new String[newLength][];
-                    int cnt = 0;
-                    for (int i = 0; i < tagSets.length; i++) {
-                      // Skip the entries that would have been freed up (stale)
-                      // System.arraycopy would be faster, but can't use it here due to 
-                      // the conditional inclusion 
-                      if ((tagSets[i].length > 0 && tagSets[i][0] != null)
-                          || (tagSets[i].length == 0)) {
-                        String[] newTag = tagSets[i];
-                        newTagSet[cnt++] = newTag;
-                      } else {
-                      }
-                    }
-                    tagSets = newTagSet;
-                    // reset the usedOffset length;
-                    unsafe.putIntVolatile(this, usedOffset, isEqual ? cnt + 1 : cnt + 2);
-                    tagIndex = isEqual ? cnt : cnt + 1;
                     tagSets = Arrays.copyOf(tagSets, newLength);
                   }
                 }

--- a/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidIntTable.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidIntTable.java
@@ -367,10 +367,31 @@ public abstract class ConcurrentMonoidIntTable {
                 // grow tag set
                 synchronized (this) {
                   if (tagIndex >= tagSets.length) {
+                    boolean isEqual = false;
+                    if(tagIndex == tagSets.length) {
+                      isEqual = true;
+                    }
                     final int oldLength = tagSets.length;
                     final int newLength =
                         oldLength > TAGSETS_MAX_INCREMENT ? oldLength + TAGSETS_MAX_INCREMENT
                             : oldLength * 2;
+                    String[][] newTagSet = new String[newLength][];
+                    int cnt = 0;
+                    for (int i = 0; i < tagSets.length; i++) {
+                      // Skip the entries that would have been freed up (stale)
+                      // System.arraycopy would be faster, but can't use it here due to 
+                      // the conditional inclusion 
+                      if ((tagSets[i].length > 0 && tagSets[i][0] != null)
+                          || (tagSets[i].length == 0)) {
+                        String[] newTag = tagSets[i];
+                        newTagSet[cnt++] = newTag;
+                      } else {
+                      }
+                    }
+                    tagSets = newTagSet;
+                    // reset the usedOffset length;
+                    unsafe.putIntVolatile(this, usedOffset, isEqual ? cnt + 1 : cnt + 2);
+                    tagIndex = isEqual ? cnt : cnt + 1;
                     tagSets = Arrays.copyOf(tagSets, newLength);
                   }
                 }

--- a/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidLongTable.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidLongTable.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import sun.misc.Unsafe;
 
 /**
@@ -587,7 +589,7 @@ public abstract class ConcurrentMonoidLongTable implements Aggregator {
     return Arrays.hashCode(tags);
   }
 
-  public class CursorImpl implements Cursor {
+  private class CursorImpl implements Cursor {
 
     final private String[] fields;
     final private Type[] types;
@@ -598,7 +600,10 @@ public abstract class ConcurrentMonoidLongTable implements Aggregator {
     private int tableIndex;
     private final Integer[] ref;
 
-    public CursorImpl(final String[][] tagSets, final String[] fields, final Type[] types,
+    @SuppressFBWarnings(
+        value = {"EI_EXPOSE_REP2"},
+        justification = "Avoid creating copies for performance reasons.")
+    private CursorImpl(final String[][] tagSets, final String[] fields, final Type[] types,
         final boolean sorted) {
       this.fields = fields;
       this.types = types;
@@ -729,11 +734,17 @@ public abstract class ConcurrentMonoidLongTable implements Aggregator {
       return Double.longBitsToDouble(readAndResetLong(index));
     }
 
+    @SuppressFBWarnings(
+        value = {"EI_EXPOSE_REP"},
+        justification = "Avoid creating copies for performance reasons.")
     @Override
     public String[] getFields() {
       return fields;
     }
 
+    @SuppressFBWarnings(
+        value = {"EI_EXPOSE_REP"},
+        justification = "Avoid creating copies for performance reasons.")
     @Override
     public Type[] getTypes() {
       return types;

--- a/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidLongTable.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidLongTable.java
@@ -315,9 +315,9 @@ public abstract class ConcurrentMonoidLongTable implements Aggregator {
                         newTagSet[cnt++] = newTag;
                       }
                     }
-                    tagSets = newTagSet;
                     // reset the usedOffset length;
                     unsafe.putIntVolatile(this, usedOffset, isEqual ? cnt + 1 : cnt + 2);
+                    tagSets = newTagSet;
                     tagIndex = isEqual ? cnt : cnt + 1;
                   }
                 }
@@ -613,7 +613,7 @@ public abstract class ConcurrentMonoidLongTable implements Aggregator {
       }
       this.tagSets = tagSets;
       if (sorted) {
-        TagSetsHelper comparator = new TagSetsHelper(tagSets); 
+        TagSetsComparator comparator = new TagSetsComparator(tagSets); 
         Arrays.sort(sortedRef, comparator);
       }
     }

--- a/core/src/main/java/io/ultrabrew/metrics/data/CursorEntry.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/CursorEntry.java
@@ -31,8 +31,10 @@ public interface CursorEntry {
    * 
    * Resets the current row to default value (0) so it can be reused for a different field
    * 
+   * @return the tag set that's marked for release, null if the current row can not be released
+   * 
    */
-  void freeCurrentRow();
+  String[] freeCurrentRow();
 
   /**
    * Retrieves a long value for a field value at given index.

--- a/core/src/main/java/io/ultrabrew/metrics/data/CursorEntry.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/CursorEntry.java
@@ -26,6 +26,13 @@ public interface CursorEntry {
    * @return last updated time, measured in milliseconds since midnight, January 1, 1970 UTC.
    */
   long lastUpdated();
+  
+  /**
+   * 
+   * Resets the current row to default value (0) so it can be reused for a different field
+   * 
+   */
+  void freeCurrentRow();
 
   /**
    * Retrieves a long value for a field value at given index.

--- a/core/src/main/java/io/ultrabrew/metrics/data/MultiCursor.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/MultiCursor.java
@@ -25,7 +25,7 @@ public class MultiCursor {
     // Update cursors
     if (next != null) {
       for (int i = 0, l = cursors.length; i < l; i++) {
-        if (nextTagSets[i] != null && TagSetsHelper.compare(next, nextTagSets[i]) == 0) {
+        if (nextTagSets[i] != null && TagSetsComparator.compare(next, nextTagSets[i]) == 0) {
           nextTagSets[i] = cursors[i].next() ? cursors[i].getTags() : null;
         }
       }
@@ -38,7 +38,7 @@ public class MultiCursor {
     // Find the next lexical tag set
     for (int i = 0, l = cursors.length; i < l; i++) {
       if (nextTagSets[i] != null) {
-        if (next == null || TagSetsHelper.compare(nextTagSets[i], next) < 0) {
+        if (next == null || TagSetsComparator.compare(nextTagSets[i], next) < 0) {
           next = nextTagSets[i];
         }
       }
@@ -60,7 +60,7 @@ public class MultiCursor {
     }
     cursorIndex++;
     for (int l = cursors.length; cursorIndex < l; cursorIndex++) {
-      if (TagSetsHelper.compare(next, nextTagSets[cursorIndex]) == 0) {
+      if (TagSetsComparator.compare(next, nextTagSets[cursorIndex]) == 0) {
         return cursors[cursorIndex];
       }
     }

--- a/core/src/main/java/io/ultrabrew/metrics/data/TagSetsComparator.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/TagSetsComparator.java
@@ -7,7 +7,7 @@ package io.ultrabrew.metrics.data;
 import java.io.Serializable;
 import java.util.Comparator;
 
-class TagSetsHelper implements Comparator<Integer>, Serializable {
+class TagSetsComparator implements Comparator<Integer>, Serializable {
 
   /**
    * Compares its two arguments for order. Returns a negative integer, zero, or a positive integer
@@ -19,7 +19,7 @@ class TagSetsHelper implements Comparator<Integer>, Serializable {
    * equal to, or greater than the second.
    */
   private final String[][] set;
-  public TagSetsHelper(String[][] set) {
+  public TagSetsComparator(String[][] set) {
     this.set = set;
   }
   

--- a/core/src/main/java/io/ultrabrew/metrics/data/TagSetsHelper.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/TagSetsHelper.java
@@ -4,7 +4,10 @@
 
 package io.ultrabrew.metrics.data;
 
-class TagSetsHelper {
+import java.io.Serializable;
+import java.util.Comparator;
+
+class TagSetsHelper implements Comparator<Integer>, Serializable {
 
   /**
    * Compares its two arguments for order. Returns a negative integer, zero, or a positive integer
@@ -15,7 +18,68 @@ class TagSetsHelper {
    * @return a negative integer, zero, or a positive integer as the first argument is less than,
    * equal to, or greater than the second.
    */
+  private final String[][] set;
+  public TagSetsHelper(String[][] set) {
+    this.set = set;
+  }
+  
+  @Override
+  public int compare(final Integer i1, final Integer i2) {
+    if(i1 == null && i2 == null) {
+      return 0;
+    }
+    
+    if (i2 == null) {
+      return -1;
+    }
+    if (i1 == null) {
+      return 1;
+    }
+    
+    if (i1 >= set.length) {
+      throw new IndexOutOfBoundsException(
+          "Set length is " + set.length + " and index passed is " + i1);
+    }
+    if (i2 >= set.length) {
+      throw new IndexOutOfBoundsException(
+          "Set length is " + set.length + " and index passed is " + i2);
+    }
+    String[] o1 = set[i1];
+    String[] o2 = set[i2];
+    if (o1 == null && o2 == null) {
+      return 0;
+    }
+    if (o2 == null) {
+      return -1;
+    }
+    if (o1 == null) {
+      return 1;
+    }
+
+    final int len1 = o1.length;
+    final int len2 = o2.length;
+    final int lim = Math.min(len1, len2);
+
+    for (int k = 0; k < lim; k++) {
+      if (o1[k] == null && o2[k] != null) {
+        return 1;
+      }
+      if (o1[k] != null && o2[k] == null) {
+        return -1;
+      }
+      if (o1[k] != null && o2[k] != null) {
+        int i = o1[k].compareTo(o2[k]);
+        if (i != 0) {
+          return i;
+        }
+      }
+    }
+
+    return len1 - len2;
+  }
+  
   static int compare(final String[] o1, final String[] o2) {
+
     if (o1 == null && o2 == null) {
       return 0;
     }

--- a/core/src/main/java/io/ultrabrew/metrics/reporters/AggregatingReporter.java
+++ b/core/src/main/java/io/ultrabrew/metrics/reporters/AggregatingReporter.java
@@ -96,12 +96,12 @@ public abstract class AggregatingReporter implements Reporter {
     public Type[] getTypes() {
       throw new IllegalStateException("Cursor has no valid data");
     }
-    // CLOVER:ON
 
     @Override
-    public void freeCurrentRow() {
-      throw new IllegalStateException("Cursor has no valid data");
+    public String[] freeCurrentRow() {
+      throw new IllegalStateException("Cursor can not free the current row");
     }
+    // CLOVER:ON
   };
 
   /**

--- a/core/src/main/java/io/ultrabrew/metrics/reporters/AggregatingReporter.java
+++ b/core/src/main/java/io/ultrabrew/metrics/reporters/AggregatingReporter.java
@@ -97,6 +97,11 @@ public abstract class AggregatingReporter implements Reporter {
       throw new IllegalStateException("Cursor has no valid data");
     }
     // CLOVER:ON
+
+    @Override
+    public void freeCurrentRow() {
+      throw new IllegalStateException("Cursor has no valid data");
+    }
   };
 
   /**

--- a/core/src/test/java/io/ultrabrew/metrics/data/BasicCounterAggregatorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/BasicCounterAggregatorTest.java
@@ -20,8 +20,6 @@ import mockit.Deencapsulation;
 import mockit.Expectations;
 import org.junit.jupiter.api.Test;
 
-import io.ultrabrew.metrics.data.ConcurrentMonoidLongTable.CursorImpl;
-
 public class BasicCounterAggregatorTest {
 
   private long CURRENT_TIME = System.currentTimeMillis();

--- a/core/src/test/java/io/ultrabrew/metrics/data/BasicCounterAggregatorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/BasicCounterAggregatorTest.java
@@ -67,7 +67,7 @@ public class BasicCounterAggregatorTest {
       }
     }
   }
-
+  
   @Test
   public void testReadAndReset() {
     final BasicCounterAggregator table = new BasicCounterAggregator("test", DEFAULT_MAX_CARDINALITY, 10);
@@ -111,6 +111,121 @@ public class BasicCounterAggregatorTest {
 
     assertEquals(3, aggregator.size());
     assertEquals(3, aggregator.capacity()); // caped at the max capacity.
+  }
+  
+  @Test
+  public void testFreeCurrentRowAndPurge() {
+    final BasicCounterAggregator table = new BasicCounterAggregator("test", DEFAULT_MAX_CARDINALITY, 3);
+
+    table.apply(new String[]{"testTag", "value"}, 100L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 10L, CURRENT_TIME);
+    Cursor cursor = table.cursor();
+    assertTrue(cursor.next());
+    assertArrayEquals(new String[]{"sum"}, cursor.getFields());
+    assertArrayEquals(new String[]{"testTag", "value"}, cursor.getTags());
+    assertEquals(110L, cursor.readLong(0));
+    assertEquals(1, table.size());
+
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 10L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 1L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 99L, CURRENT_TIME);
+    assertEquals(2, table.size());
+    table.apply(new String[]{"testTag", "value2"}, 2L, CURRENT_TIME - 2*60*1000l);
+    assertEquals(3, table.size());
+
+    String[] tagSet1 = new String[]{"testTag", "value"};
+    String[] tagSet2 = new String[]{"testTag", "value", "testTag2", "value2"};
+    String[] tagSet3 = new String[]{"testTag", "value3"};
+
+    assertEquals(3, table.capacity());
+    assertEquals(3, table.size());
+    cursor = table.cursor();
+    while (cursor.next()) {
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      }
+    }
+
+    table.apply(new String[]{"testTag", "value3"}, 3L, CURRENT_TIME - 2*60*1000l);
+    assertEquals(3, table.size());
+    
+    cursor = table.cursor();
+    while (cursor.next()) {
+      final int hash = Arrays.hashCode(cursor.getTags());
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      } else {
+        assertEquals(CURRENT_TIME, cursor.lastUpdated());
+      }
+      if (hash == Arrays.hashCode(tagSet1)) {
+        assertEquals(111L, cursor.readLong(0));
+      } else if (hash == Arrays.hashCode(tagSet2)) {
+        assertEquals(109L, cursor.readLong(0));
+      } else if (hash == Arrays.hashCode(tagSet3)) {
+        assertEquals(3L, cursor.readLong(0));
+      } else {
+        fail("Unknown hashcode");
+      }
+    }
+  }
+  
+  @Test
+  public void testFreeCurrentRow() {
+    final BasicCounterAggregator table = new BasicCounterAggregator("test", DEFAULT_MAX_CARDINALITY, 10);
+    
+    table.apply(new String[]{"testTag", "value"}, 100L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 10L, CURRENT_TIME);
+    Cursor cursor = table.cursor();
+    assertTrue(cursor.next());
+    assertArrayEquals(new String[]{"sum"}, cursor.getFields());
+    assertArrayEquals(new String[]{"testTag", "value"}, cursor.getTags());
+    assertEquals(110L, cursor.readLong(0));
+    assertEquals(1, table.size());
+    
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 10L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 1L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 99L, CURRENT_TIME);
+    assertEquals(2, table.size());
+    table.apply(new String[]{"testTag", "value2"}, 2L, CURRENT_TIME - 2*60*1000l);
+    table.apply(new String[]{"testTag", "value4"}, 1L, CURRENT_TIME - 1*60*1000l);
+    table.apply(new String[]{"testTag", "value5"}, 8L, CURRENT_TIME - 3*60*1000l);
+    assertEquals(5, table.size());
+    
+    String[] tagSet1 = new String[]{"testTag", "value"};
+    String[] tagSet2 = new String[]{"testTag", "value", "testTag2", "value2"};
+    String[] tagSet3 = new String[]{"testTag", "value2"};
+    String[] tagSet4 = new String[]{"testTag", "value3"};
+    
+    assertEquals(10, table.capacity());
+    assertEquals(5, table.size());
+    cursor = table.cursor();
+    while (cursor.next()) {
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      }
+    }
+    assertEquals(5, table.size());
+    table.apply(new String[]{"testTag", "value3"}, 3L, CURRENT_TIME - 2*60*1000l);
+    assertEquals(6, table.size());
+    
+    cursor = table.cursor();
+    while (cursor.next()) {
+      final int hash = Arrays.hashCode(cursor.getTags());
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      } else {
+        assertEquals(CURRENT_TIME, cursor.lastUpdated());
+      }
+      if (hash == Arrays.hashCode(tagSet1)) {
+        assertEquals(111L, cursor.readLong(0));
+      } else if (hash == Arrays.hashCode(tagSet2)) {
+        assertEquals(109L, cursor.readLong(0));
+      } else if (hash == Arrays.hashCode(tagSet4)) {
+        assertEquals(3L, cursor.readLong(0));
+      } else {
+        fail("Unknown hashcode");
+      }
+    }
   }
 
   @Test
@@ -355,7 +470,6 @@ public class BasicCounterAggregatorTest {
 
   @Test
   public void tagTableGrowthIsSynchronized() throws InterruptedException {
-
     int requestedCapacity = 131072;
     final BasicCounterAggregator aggregator = new BasicCounterAggregator("test", 1_048_576,
         requestedCapacity);
@@ -372,6 +486,7 @@ public class BasicCounterAggregatorTest {
         try {
           Thread.sleep(100);
           aggregator.apply(new String[]{"testTag", String.valueOf(262145)}, 1L, CURRENT_TIME);
+          aggregator.apply(new String[]{"testTag", String.valueOf(262147)}, 1L, CURRENT_TIME);
         } catch (InterruptedException ignored) {
         }
       }
@@ -379,8 +494,10 @@ public class BasicCounterAggregatorTest {
 
     Thread t2 = new Thread(() -> {
       aggregator.apply(new String[]{"testTag", String.valueOf(262146)}, 1L, CURRENT_TIME);
+      aggregator.apply(new String[]{"testTag", String.valueOf(262148)}, 1L, CURRENT_TIME);
+      aggregator.apply(new String[]{"testTag", String.valueOf(262149)}, 1L, CURRENT_TIME);
     }, "t2");
-
+    
     t1.start();
     Thread.sleep(5);
     t2.start();
@@ -391,7 +508,7 @@ public class BasicCounterAggregatorTest {
     int oldLength = tagSets.length;
     tagSets = Deencapsulation.getField(aggregator, "tagSets");
     assertEquals(oldLength + requestedCapacity, tagSets.length);
-    assertEquals(262146, aggregator.size()); // ensures nothing is dropped.
+    assertEquals(262149, aggregator.size()); // ensures nothing is dropped.
   }
 
   @Test

--- a/core/src/test/java/io/ultrabrew/metrics/data/BasicCounterAggregatorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/BasicCounterAggregatorTest.java
@@ -166,6 +166,11 @@ public class BasicCounterAggregatorTest {
       } else {
         fail("Unknown hashcode");
       }
+      
+      cursor = table.sortedCursor();
+      while(cursor.next()) {
+        cursor.freeCurrentRow();
+      }
     }
   }
   

--- a/core/src/test/java/io/ultrabrew/metrics/data/BasicGaugeAggregatorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/BasicGaugeAggregatorTest.java
@@ -100,6 +100,155 @@ public class BasicGaugeAggregatorTest {
     assertEquals(Long.MIN_VALUE, cursor.readLong(3)); // max
     assertEquals(0L, cursor.readLong(4)); // lastValue
   }
+  
+  @Test
+  public void testFreeCurrentRowAndPurge() {
+    final BasicGaugeAggregator table = new BasicGaugeAggregator("test", DEFAULT_MAX_CARDINALITY, 3);
+
+    table.apply(new String[]{"testTag", "value"}, 100L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 10L, CURRENT_TIME);
+    Cursor cursor = table.cursor();
+    assertTrue(cursor.next());
+    assertArrayEquals(new String[]{"count", "sum", "min", "max", "lastValue"}, cursor.getFields());
+    assertArrayEquals(new String[]{"testTag", "value"}, cursor.getTags());
+    assertEquals(CURRENT_TIME, cursor.lastUpdated()); // last updated timestamp
+    assertEquals(2L, cursor.readLong(0)); // count
+    assertEquals(110L, cursor.readLong(1)); // sum
+    assertEquals(10L, cursor.readLong(2)); // min
+    assertEquals(100L, cursor.readLong(3)); // max
+    assertEquals(10L, cursor.readLong(4)); // lastValue
+    assertEquals(1, table.size());
+
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 10L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 1L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 99L, CURRENT_TIME);
+    assertEquals(2, table.size());
+    table.apply(new String[]{"testTag", "value2"}, 2L, CURRENT_TIME - 2*60*1000l);
+    assertEquals(3, table.size());
+
+    String[] tagSet1 = new String[]{"testTag", "value"};
+    String[] tagSet2 = new String[]{"testTag", "value", "testTag2", "value2"};
+    String[] tagSet3 = new String[]{"testTag", "value3"};
+
+    assertEquals(3, table.capacity());
+    assertEquals(3, table.size());
+    cursor = table.cursor();
+    while (cursor.next()) {
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      }
+    }
+
+    table.apply(new String[]{"testTag", "value3"}, 3L, CURRENT_TIME - 2*60*1000l);
+    assertEquals(3, table.size());
+    
+    cursor = table.cursor();
+    while (cursor.next()) {
+      final int hash = Arrays.hashCode(cursor.getTags());
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      } else {
+        assertEquals(CURRENT_TIME, cursor.lastUpdated());
+      }
+      if (hash == Arrays.hashCode(tagSet1)) {
+        assertEquals(3L, cursor.readAndResetLong(0)); // count
+        assertEquals(111L, cursor.readAndResetLong(1)); // sum
+        assertEquals(1L, cursor.readAndResetLong(2)); // min
+        assertEquals(100L, cursor.readAndResetLong(3)); // max
+        assertEquals(1L, cursor.readAndResetLong(4)); // lastValue
+      } else if (hash == Arrays.hashCode(tagSet2)) {
+        assertEquals(2L, cursor.readLong(0));
+        assertEquals(109L, cursor.readLong(1));
+        assertEquals(10L, cursor.readLong(2));
+        assertEquals(99L, cursor.readLong(3));
+        assertEquals(99L, cursor.readLong(4));
+      } else if (hash == Arrays.hashCode(tagSet3)) {
+        assertEquals(1L, cursor.readLong(0));
+        assertEquals(3L, cursor.readLong(1));
+        assertEquals(3L, cursor.readLong(2));
+        assertEquals(3L, cursor.readLong(3));
+        assertEquals(3L, cursor.readLong(4));
+      } else {
+        fail("Unknown hashcode");
+      }
+    }
+  }
+  
+  @Test
+  public void testFreeCurrentRow() {
+ 
+    final BasicGaugeAggregator table = new BasicGaugeAggregator("test", DEFAULT_MAX_CARDINALITY, 10);
+
+    table.apply(new String[]{"testTag", "value"}, 100L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 10L, CURRENT_TIME);
+    Cursor cursor = table.cursor();
+    assertTrue(cursor.next());
+    assertArrayEquals(new String[]{"count", "sum", "min", "max", "lastValue"}, cursor.getFields());
+    assertArrayEquals(new String[]{"testTag", "value"}, cursor.getTags());
+    assertEquals(CURRENT_TIME, cursor.lastUpdated()); // last updated timestamp
+    assertEquals(2L, cursor.readLong(0)); // count
+    assertEquals(110L, cursor.readLong(1)); // sum
+    assertEquals(10L, cursor.readLong(2)); // min
+    assertEquals(100L, cursor.readLong(3)); // max
+    assertEquals(10L, cursor.readLong(4)); // lastValue
+    assertEquals(1, table.size());
+    
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 10L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value"}, 1L, CURRENT_TIME);
+    table.apply(new String[]{"testTag", "value", "testTag2", "value2"}, 99L, CURRENT_TIME);
+    assertEquals(2, table.size());
+    table.apply(new String[]{"testTag", "value2"}, 2L, CURRENT_TIME - 2*60*1000l);
+    table.apply(new String[]{"testTag", "value4"}, 1L, CURRENT_TIME - 1*60*1000l);
+    table.apply(new String[]{"testTag", "value5"}, 8L, CURRENT_TIME - 3*60*1000l);
+    assertEquals(5, table.size());
+    
+    String[] tagSet1 = new String[]{"testTag", "value"};
+    String[] tagSet2 = new String[]{"testTag", "value", "testTag2", "value2"};
+    String[] tagSet3 = new String[]{"testTag", "value3"};
+    
+    assertEquals(10, table.capacity());
+    assertEquals(5, table.size());
+    cursor = table.cursor();
+    while (cursor.next()) {
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      }
+    }
+    assertEquals(5, table.size());
+    table.apply(new String[]{"testTag", "value3"}, 3L, CURRENT_TIME - 2*60*1000l);
+    assertEquals(6, table.size());
+    
+    cursor = table.cursor();
+    while (cursor.next()) {
+      final int hash = Arrays.hashCode(cursor.getTags());
+      if(cursor.lastUpdated() < CURRENT_TIME) {
+        cursor.freeCurrentRow();
+      } else {
+        assertEquals(CURRENT_TIME, cursor.lastUpdated());
+      }
+      if (hash == Arrays.hashCode(tagSet1)) {
+        assertEquals(3L, cursor.readAndResetLong(0)); // count
+        assertEquals(111L, cursor.readAndResetLong(1)); // sum
+        assertEquals(1L, cursor.readAndResetLong(2)); // min
+        assertEquals(100L, cursor.readAndResetLong(3)); // max
+        assertEquals(1L, cursor.readAndResetLong(4)); // lastValue
+      } else if (hash == Arrays.hashCode(tagSet2)) {
+        assertEquals(2L, cursor.readLong(0));
+        assertEquals(109L, cursor.readLong(1));
+        assertEquals(10L, cursor.readLong(2));
+        assertEquals(99L, cursor.readLong(3));
+        assertEquals(99L, cursor.readLong(4));
+      } else if (hash == Arrays.hashCode(tagSet3)) {
+        assertEquals(1L, cursor.readLong(0));
+        assertEquals(3L, cursor.readLong(1));
+        assertEquals(3L, cursor.readLong(2));
+        assertEquals(3L, cursor.readLong(3));
+        assertEquals(3L, cursor.readLong(4));
+      } else {
+        fail("Unknown hashcode");
+      }
+    }
+  }
 
   @Test
   public void testGrowTableWithMaxCapacity() {

--- a/core/src/test/java/io/ultrabrew/metrics/data/BasicGaugeAggregatorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/BasicGaugeAggregatorTest.java
@@ -217,7 +217,6 @@ public class BasicGaugeAggregatorTest {
     assertEquals(5, table.size());
     table.apply(new String[]{"testTag", "value3"}, 3L, CURRENT_TIME - 2*60*1000l);
     assertEquals(6, table.size());
-    
     cursor = table.cursor();
     while (cursor.next()) {
       final int hash = Arrays.hashCode(cursor.getTags());

--- a/core/src/test/java/io/ultrabrew/metrics/data/MultiCursorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/MultiCursorTest.java
@@ -72,7 +72,6 @@ public class MultiCursorTest {
       assertNull(multiCursor.nextCursorEntry());
     }
     assertFalse(multiCursor.next());
-
     assertEquals(4, records.size());
     assertThat(records.get(tagSet1), containsInAnyOrder("gauge", "counter"));
     // Because timerAggregator is first in the list, its tagset2b is used for both

--- a/core/src/test/java/io/ultrabrew/metrics/data/TagSetsHelperTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/TagSetsHelperTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TagSetsHelperTest {
@@ -71,5 +72,97 @@ public class TagSetsHelperTest {
     assertThat(TagSetsHelper.compare(tagSet1, tagSet2), greaterThan(0));
     assertThat(TagSetsHelper.compare(tagSet3, tagSet1), greaterThan(0));
     assertThat(TagSetsHelper.compare(tagSet3, tagSet2), greaterThan(0));
+  }
+  
+  @Test
+  public void testComparator() {
+    final String[] tagSet1 = new String[] {"testTag", null};
+    final String[] tagSet2 = new String[] {"testTag", "value"};
+    final String[] tagSet3 = new String[] {null, "value"};
+    final String[] tagSet4 = new String[] {null, null};
+    String[][] tagSet = new String[5][2];
+    tagSet[0] = tagSet1;
+    tagSet[1] = tagSet2;
+    tagSet[2] = tagSet3;
+    tagSet[3] = tagSet4;
+    tagSet[4] = null;
+    TagSetsHelper comparator = new TagSetsHelper(tagSet);
+    Integer first = null;
+    Integer second = null;
+
+    int compare = comparator.compare(first, second);
+    assertEquals(compare, 0);
+
+    first = null;
+    second = 0;
+    compare = comparator.compare(first, second);
+    assertEquals(compare, 1);
+    first = 0;
+    second = null;
+    compare = comparator.compare(first, second);
+    assertEquals(compare, -1);
+
+    first = 1;
+    second = 1;
+    compare = comparator.compare(first, second);
+    assertEquals(compare, 0);
+
+    first = 4;
+    compare = comparator.compare(first, second);
+    
+    first = 1;
+    second = 4;
+    compare = comparator.compare(first, second);
+    
+    first = 5;
+    try {
+      compare = comparator.compare(first, second);
+      Assertions.fail("Index is out of bounds, should have been caught");
+    } catch (Exception e) {
+    }
+    first = 1;
+    second = 5;
+    try {
+      compare = comparator.compare(first, second);
+      Assertions.fail("Index is out of bounds, should have been caught");
+    } catch (Exception e) {
+    }
+  }
+  
+  @Test
+  public void testNullComparator() {
+    final String[] tagSet1 = new String[]{"testTag", null};
+    final String[] tagSet2 = new String[]{"testTag", "value"};
+    final String[] tagSet3 = new String[]{null, "value"};
+    
+    String[][] tagSet = new String[3][2];
+    tagSet[0] = tagSet1;
+    tagSet[1] = tagSet2;
+    tagSet[2] = tagSet3;
+    TagSetsHelper comparator = new TagSetsHelper(tagSet);
+    Integer first = 0;
+    Integer second = 1;
+    assertEquals(1, comparator.compare(first, second));
+    
+    first = 1;
+    second = 0;
+    assertEquals(-1, comparator.compare(first, second));
+    
+    first = 0;
+    second = 2;
+    assertEquals(-1, comparator.compare(first, second));
+    
+    first = 0;
+    second = 0;
+    assertEquals(0, comparator.compare(first, second));
+    
+    first = 2;
+    second = 0;
+    assertEquals(1, comparator.compare(first, second));
+    
+    first = 2;
+    second = 2;
+    assertEquals(0, comparator.compare(first, second));
+    
   }
 }

--- a/core/src/test/java/io/ultrabrew/metrics/data/TagSetsHelperTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/data/TagSetsHelperTest.java
@@ -23,36 +23,36 @@ public class TagSetsHelperTest {
     final String[] tagSet5 = new String[]{"testTag3", "value"};
     final String[] tagSet6 = null;
 
-    assertEquals(0, TagSetsHelper.compare(tagSet1, tagSet1));
-    assertEquals(0, TagSetsHelper.compare(tagSet2, tagSet2));
-    assertEquals(0, TagSetsHelper.compare(tagSet3, tagSet3));
-    assertEquals(0, TagSetsHelper.compare(tagSet4, tagSet4));
-    assertEquals(0, TagSetsHelper.compare(tagSet4, tagSet5));
-    assertEquals(0, TagSetsHelper.compare(tagSet6, tagSet6));
+    assertEquals(0, TagSetsComparator.compare(tagSet1, tagSet1));
+    assertEquals(0, TagSetsComparator.compare(tagSet2, tagSet2));
+    assertEquals(0, TagSetsComparator.compare(tagSet3, tagSet3));
+    assertEquals(0, TagSetsComparator.compare(tagSet4, tagSet4));
+    assertEquals(0, TagSetsComparator.compare(tagSet4, tagSet5));
+    assertEquals(0, TagSetsComparator.compare(tagSet6, tagSet6));
 
-    assertThat(TagSetsHelper.compare(tagSet1, tagSet2), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet1, tagSet3), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet1, tagSet4), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet2, tagSet3), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet2, tagSet4), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet3, tagSet4), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet1, tagSet2), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet1, tagSet3), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet1, tagSet4), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet2, tagSet3), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet2, tagSet4), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet3, tagSet4), lessThan(0));
 
-    assertThat(TagSetsHelper.compare(tagSet1, tagSet6), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet2, tagSet6), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet3, tagSet6), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet4, tagSet6), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet1, tagSet6), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet2, tagSet6), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet3, tagSet6), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet4, tagSet6), lessThan(0));
 
-    assertThat(TagSetsHelper.compare(tagSet5, tagSet3), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet5, tagSet2), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet5, tagSet1), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet3, tagSet2), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet3, tagSet1), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet2, tagSet1), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet5, tagSet3), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet5, tagSet2), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet5, tagSet1), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet3, tagSet2), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet3, tagSet1), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet2, tagSet1), greaterThan(0));
 
-    assertThat(TagSetsHelper.compare(tagSet6, tagSet4), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet6, tagSet3), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet6, tagSet2), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet6, tagSet1), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet6, tagSet4), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet6, tagSet3), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet6, tagSet2), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet6, tagSet1), greaterThan(0));
   }
 
   @Test
@@ -61,17 +61,17 @@ public class TagSetsHelperTest {
     final String[] tagSet2 = new String[]{"testTag", "value"};
     final String[] tagSet3 = new String[]{null, "value"};
 
-    assertEquals(0, TagSetsHelper.compare(tagSet1, tagSet1));
-    assertEquals(0, TagSetsHelper.compare(tagSet2, tagSet2));
-    assertEquals(0, TagSetsHelper.compare(tagSet3, tagSet3));
+    assertEquals(0, TagSetsComparator.compare(tagSet1, tagSet1));
+    assertEquals(0, TagSetsComparator.compare(tagSet2, tagSet2));
+    assertEquals(0, TagSetsComparator.compare(tagSet3, tagSet3));
 
-    assertThat(TagSetsHelper.compare(tagSet2, tagSet1), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet2, tagSet3), lessThan(0));
-    assertThat(TagSetsHelper.compare(tagSet1, tagSet3), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet2, tagSet1), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet2, tagSet3), lessThan(0));
+    assertThat(TagSetsComparator.compare(tagSet1, tagSet3), lessThan(0));
 
-    assertThat(TagSetsHelper.compare(tagSet1, tagSet2), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet3, tagSet1), greaterThan(0));
-    assertThat(TagSetsHelper.compare(tagSet3, tagSet2), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet1, tagSet2), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet3, tagSet1), greaterThan(0));
+    assertThat(TagSetsComparator.compare(tagSet3, tagSet2), greaterThan(0));
   }
   
   @Test
@@ -86,7 +86,7 @@ public class TagSetsHelperTest {
     tagSet[2] = tagSet3;
     tagSet[3] = tagSet4;
     tagSet[4] = null;
-    TagSetsHelper comparator = new TagSetsHelper(tagSet);
+    TagSetsComparator comparator = new TagSetsComparator(tagSet);
     Integer first = null;
     Integer second = null;
 
@@ -139,7 +139,7 @@ public class TagSetsHelperTest {
     tagSet[0] = tagSet1;
     tagSet[1] = tagSet2;
     tagSet[2] = tagSet3;
-    TagSetsHelper comparator = new TagSetsHelper(tagSet);
+    TagSetsComparator comparator = new TagSetsComparator(tagSet);
     Integer first = 0;
     Integer second = 1;
     assertEquals(1, comparator.compare(first, second));


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


This PR addresses https://github.com/ultrabrew/metrics/issues/26. The main idea is to let the clients take a call on purging a tagset state that is no longer needed. I've added a method `freeCurrentRow` to the `CursorEntry` so the clients can purge the current row while iterating to report the data. Piggybacked on the tagset itself when a current row is marked for deletion by setting the first tag field to null.

The currently sorted cursor iterator works on a copy of the tag sets and this PR changes that to work on the same tag sets avoiding additional memory space.
Would like to tackle the Histogram implementations in the next phase once we have agreed on the current implementation.

