### PR TITLE
More informative logging when max-cardinality is exceeded.

### DIFF
--- a/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidLongTable.java
+++ b/core/src/main/java/io/ultrabrew/metrics/data/ConcurrentMonoidLongTable.java
@@ -337,7 +337,7 @@ public abstract class ConcurrentMonoidLongTable implements Aggregator {
   private boolean growTable() {
 
     if (capacity >= maxCapacity) {
-      LOGGER.error("Maximum linear probing table capacity reached");
+      LOGGER.error("Maximum linear probing table capacity reached (needed {}, max {}, metric-id \"{}\")", capacity, maxCapacity, metricId);
       return false;
     }
 


### PR DESCRIPTION
Added the parenthesized part in this log:
Maximum linear probing table capacity reached (needed ..., max ..., metric-id "...")


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
