### PR TITLE
Ignore spotbugs tooling in dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,6 @@ subprojects {
         clover group: 'org.openclover', name: 'clover', version: '4.2.1'
 
         spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.8.0'
-
-        archives group: 'org.apache.maven.wagon', name: 'wagon-ssh-external', version: '3.2.0'
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ subprojects {
     check.dependsOn cloverGenerateReport, dependencyCheckAnalyze
 
     dependencyCheck {
-        skipConfigurations = ['clover', 'jmh']
+        skipConfigurations = ['clover', 'jmh', 'spotbugs']
         format = 'ALL'
         failBuildOnCVSS = 4.0
     }

--- a/examples/undertow-httphandler/build.gradle
+++ b/examples/undertow-httphandler/build.gradle
@@ -11,7 +11,8 @@ publishMavenJavaPublicationToMavenRepository {
 dependencies {
     compile project(':core')
 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.1'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.1'
-    compile group: 'io.undertow', name: 'undertow-core', version: '2.0.29.Final'
+    compile platform(group: 'org.apache.logging.log4j', name: 'log4j-bom', version: '2.13.3')
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl'
+    compile group: 'io.undertow', name: 'undertow-core', version: '2.1.3.Final'
 }

--- a/examples/webapp/build.gradle
+++ b/examples/webapp/build.gradle
@@ -9,8 +9,9 @@ publishMavenJavaPublicationToMavenRepository {
 dependencies {
     compile project(':core')
 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.1'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.1'
+    compile platform(group: 'org.apache.logging.log4j', name: 'log4j-bom', version: '2.13.3')
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl'
 
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 }


### PR DESCRIPTION
The intent here has been to ignore build tooling from the external dependency vulnerability check, so add spotbugs to that list to avoid unnecessary build failures.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
