### PR TITLE
Allow setting max cardinality for histograms

### DIFF
--- a/core/src/main/java/io/ultrabrew/metrics/reporters/TimeWindowReporter.java
+++ b/core/src/main/java/io/ultrabrew/metrics/reporters/TimeWindowReporter.java
@@ -4,6 +4,7 @@
 
 package io.ultrabrew.metrics.reporters;
 
+import static io.ultrabrew.metrics.Metric.DEFAULT_MAX_CARDINALITY;
 import static io.ultrabrew.metrics.reporters.AggregatingReporter.DEFAULT_AGGREGATORS;
 
 import io.ultrabrew.metrics.Metric;
@@ -191,11 +192,22 @@ public abstract class TimeWindowReporter implements Reporter, AutoCloseable {
      *
      * @param metricId identifier of the metric
      * @param bucket distribution bucket
+     * @param maxCardinality maximum cardinality of data in the histogram
      */
+    public B addHistogram(final String metricId, final DistributionBucket bucket, final int maxCardinality) {
+        this.metricAggregators
+            .put(metricId, (metric) -> new BasicHistogramAggregator(metricId, bucket, maxCardinality));
+        return (B) this;
+    }
+
+      /**
+       * Add histograms to a specific metric
+       *
+       * @param metricId identifier of the metric
+       * @param bucket distribution bucket
+       */
     public B addHistogram(final String metricId, final DistributionBucket bucket) {
-      this.metricAggregators
-          .put(metricId, (metric) -> new BasicHistogramAggregator(metricId, bucket));
-      return (B) this;
+        return addHistogram(metricId, bucket, DEFAULT_MAX_CARDINALITY);
     }
 
     public abstract R build();

--- a/core/src/main/java/io/ultrabrew/metrics/reporters/TimeWindowReporter.java
+++ b/core/src/main/java/io/ultrabrew/metrics/reporters/TimeWindowReporter.java
@@ -195,9 +195,9 @@ public abstract class TimeWindowReporter implements Reporter, AutoCloseable {
      * @param maxCardinality maximum cardinality of data in the histogram
      */
     public B addHistogram(final String metricId, final DistributionBucket bucket, final int maxCardinality) {
-        this.metricAggregators
-            .put(metricId, (metric) -> new BasicHistogramAggregator(metricId, bucket, maxCardinality));
-        return (B) this;
+      this.metricAggregators
+          .put(metricId, (metric) -> new BasicHistogramAggregator(metricId, bucket, maxCardinality));
+      return (B) this;
     }
 
       /**
@@ -207,7 +207,7 @@ public abstract class TimeWindowReporter implements Reporter, AutoCloseable {
        * @param bucket distribution bucket
        */
     public B addHistogram(final String metricId, final DistributionBucket bucket) {
-        return addHistogram(metricId, bucket, DEFAULT_MAX_CARDINALITY);
+      return addHistogram(metricId, bucket, DEFAULT_MAX_CARDINALITY);
     }
 
     public abstract R build();


### PR DESCRIPTION
The default max cardinality is not sufficient for some use cases, and there was no obvious way to override it for histograms.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
