### PR TITLE
Base64 encoding of the GPG key:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,8 @@ subprojects {
 
     signing {
         if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-            def signingKey = findProperty("signingKey")
+            def signingKeyEncoded = findProperty("signingKey")
+            def signingKey = new String(signingKeyEncoded.decodeBase64())
             def signingPassword = findProperty("signingPassword")
             useInMemoryPgpKeys(signingKey, signingPassword)
 


### PR DESCRIPTION
Travis can't parse the original format of the GPG key. As a workaround it will use the base64encoded key. The build script will have to decode the key and use it.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
