### PR TITLE
Fix JVM CodeHeap memory pool collection

### DIFF
--- a/core/src/main/java/io/ultrabrew/metrics/JvmStatisticsCollector.java
+++ b/core/src/main/java/io/ultrabrew/metrics/JvmStatisticsCollector.java
@@ -148,14 +148,14 @@ public class JvmStatisticsCollector {
 
     for (MemoryPoolMXBean poolBean : ManagementFactory.getMemoryPoolMXBeans()) {
       MemoryUsage usage = poolBean.getUsage();
-      String prefix = "jvm.memorypool." + poolBean.getName().replace(' ', '_');
+      String prefix = "jvm.memorypool." + sanitizeName(poolBean.getName());
       setGauge(prefix + ".committed", usage.getCommitted());
       setGauge(prefix + ".used", usage.getUsed());
     }
 
     for (BufferPoolMXBean bufferPoolBean : ManagementFactory
         .getPlatformMXBeans(BufferPoolMXBean.class)) {
-      String prefix = "jvm.bufferpool." + bufferPoolBean.getName().replace(' ', '_');
+      String prefix = "jvm.bufferpool." + sanitizeName(bufferPoolBean.getName());
       setGauge(prefix + ".count", bufferPoolBean.getCount());
       setGauge(prefix + ".totalCapacity", bufferPoolBean.getTotalCapacity());
       setGauge(prefix + ".memoryUsed", bufferPoolBean.getMemoryUsed());
@@ -166,5 +166,9 @@ public class JvmStatisticsCollector {
       setGauge(prefix + ".count", collectorBean.getCollectionCount());
       setGauge(prefix + ".time", collectorBean.getCollectionTime());
     }
+  }
+
+  private String sanitizeName(String name) {
+    return name.replace(' ', '_').replace('\'', '_');
   }
 }

--- a/core/src/test/java/io/ultrabrew/metrics/JvmStatisticsCollectorTest.java
+++ b/core/src/test/java/io/ultrabrew/metrics/JvmStatisticsCollectorTest.java
@@ -5,11 +5,13 @@
 package io.ultrabrew.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.jupiter.api.Test;
@@ -56,6 +58,9 @@ public class JvmStatisticsCollectorTest {
       assertEquals("jvm.thread.daemonCount", metrics.get(4).id);
       assertEquals("jvm.thread.count", metrics.get(5).id);
       assertEquals("jvm.thread.totalStartedCount", metrics.get(6).id);
+
+      metrics.forEach(m -> assertFalse(m.id.contains(" "), "Metric ID [" + m.id + "] contains illegal character"));
+      metrics.forEach(m -> assertFalse(m.id.contains("'"), "Metric ID [" + m.id + "] contains illegal character"));
 
       // There are some unverified items here, but they depend on the VM we're running on and are thus hard to verify
       // For the same reason, we can't verify the number of calls to reporter.emit() as it depends on the VM


### PR DESCRIPTION
Since Java 9, code heap was split into three different pools. Their names containing single-quote (`'`) which is not acceptable by my metric collector. To be honest, I think most collector does not like single-quote. Therefore, it makes sense to sanitize the names (like it did with the space character) in the Ultrabrew Metrics library.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
